### PR TITLE
Feature/type consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* Update dependencies.
+* [#22](https://github.com/shlinkio/shlink-js-sdk/issues/22) Consolidate exposed types, making them more consistent.
+
+  * Types no longer couple with HTTP terminology, removing references to body, query, request, response, etc.
+  * All types that wrap a list of entities are now suffixed with `List` (`ShlinkShortUrlsList`, `ShlinkVisitsList`, etc.)
+  * Arguments passed to the API client frequently use the `Params` suffix when representing filters (like `ShlinkVisitsParams`) or `Data` suffix when wrapping props to be mutated (like `ShlinkEditShortUrlData`).
+  * Methods returning entities, just use the name of the entity itself, regardless of the method's nature (fetch or mutation).
+  * Methods returning the result of a mutation when it is not an entity, will return types using the `Result` suffix (like `ShlinkDeleteVisitsResult`).
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* [#74](https://github.com/shlinkio/shlink-js-sdk/issues/74) Drop support for Shlink older than 3.3.0. This version introduced the API v3, so this allows to remove the logic to fall back to v2, and remove the error types used in v2.
+
+### Fixed
+* *Nothing*
+
+
 ## [0.2.2] - 2024-01-20
 ### Added
 * *Nothing*

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
     },
-    "./browser": {
-      "import": "./dist/browser.js",
-      "require": "./dist/browser.cjs",
-      "types": "./dist/browser.d.ts"
-    },
     "./api-contract": {
       "import": "./dist/api-contract.js",
       "require": "./dist/api-contract.cjs",
       "types": "./dist/api-contract.d.ts"
+    },
+    "./browser": {
+      "import": "./dist/browser.js",
+      "require": "./dist/browser.cjs",
+      "types": "./dist/browser.d.ts"
     },
     "./node": {
       "import": "./dist/node.js",

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -1,42 +1,28 @@
 import type {
   ShlinkCreateShortUrlData,
-  ShlinkDeleteVisitsResponse,
+  ShlinkDeleteVisitsResult,
   ShlinkDomainRedirects,
-  ShlinkDomainsResponse,
+  ShlinkDomainsList,
   ShlinkEditDomainRedirects,
   ShlinkEditShortUrlData,
   ShlinkHealth,
   ShlinkMercureInfo,
   ShlinkShortUrl,
+  ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
-  ShlinkShortUrlsResponse,
   ShlinkShortUrlVisitsParams,
   ShlinkTags,
-  ShlinkVisits,
+  ShlinkVisitsList,
   ShlinkVisitsOverview,
   ShlinkVisitsParams,
 } from './types';
 
 export type ShlinkApiClient = {
-  listShortUrls(params?: ShlinkShortUrlsListParams): Promise<ShlinkShortUrlsResponse>;
+  // Short URLs
+
+  listShortUrls(params?: ShlinkShortUrlsListParams): Promise<ShlinkShortUrlsList>;
 
   createShortUrl(options: ShlinkCreateShortUrlData): Promise<ShlinkShortUrl>;
-
-  getShortUrlVisits(shortCode: string, query?: ShlinkShortUrlVisitsParams): Promise<ShlinkVisits>;
-
-  deleteShortUrlVisits(shortCode: string, domain?: string | null): Promise<ShlinkDeleteVisitsResponse>;
-
-  getTagVisits(tag: string, query?: ShlinkVisitsParams): Promise<ShlinkVisits>;
-
-  getDomainVisits(domain: string, query?: ShlinkVisitsParams): Promise<ShlinkVisits>;
-
-  getOrphanVisits(query?: ShlinkVisitsParams): Promise<ShlinkVisits>;
-
-  deleteOrphanVisits(): Promise<ShlinkDeleteVisitsResponse>;
-
-  getNonOrphanVisits(query?: ShlinkVisitsParams): Promise<ShlinkVisits>;
-
-  getVisitsOverview(): Promise<ShlinkVisitsOverview>;
 
   getShortUrl(shortCode: string, domain?: string | null): Promise<ShlinkShortUrl>;
 
@@ -45,8 +31,28 @@ export type ShlinkApiClient = {
   updateShortUrl(
     shortCode: string,
     domain: string | null | undefined,
-    body: ShlinkEditShortUrlData,
+    data: ShlinkEditShortUrlData,
   ): Promise<ShlinkShortUrl>;
+
+  // Visits
+
+  getVisitsOverview(): Promise<ShlinkVisitsOverview>;
+
+  getShortUrlVisits(shortCode: string, params?: ShlinkShortUrlVisitsParams): Promise<ShlinkVisitsList>;
+
+  getTagVisits(tag: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+
+  getDomainVisits(domain: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+
+  getOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+
+  getNonOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+
+  deleteShortUrlVisits(shortCode: string, domain?: string | null): Promise<ShlinkDeleteVisitsResult>;
+
+  deleteOrphanVisits(): Promise<ShlinkDeleteVisitsResult>;
+
+  // Tags
 
   listTags(): Promise<ShlinkTags>;
 
@@ -56,11 +62,15 @@ export type ShlinkApiClient = {
 
   editTag(oldName: string, newName: string): Promise<{ oldName: string; newName: string }>;
 
+  // Domains
+
+  listDomains(): Promise<ShlinkDomainsList>;
+
+  editDomainRedirects(domainRedirects: ShlinkEditDomainRedirects): Promise<ShlinkDomainRedirects>;
+
+  // Misc
+
   health(authority?: string): Promise<ShlinkHealth>;
 
   mercureInfo(): Promise<ShlinkMercureInfo>;
-
-  listDomains(): Promise<ShlinkDomainsResponse>;
-
-  editDomainRedirects(domainRedirects: ShlinkEditDomainRedirects): Promise<ShlinkDomainRedirects>;
 };

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -11,7 +11,8 @@ import type {
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
   ShlinkShortUrlVisitsParams,
-  ShlinkTags,
+  ShlinkTagsList,
+  ShlinkTagsStatsList,
   ShlinkVisitsList,
   ShlinkVisitsOverview,
   ShlinkVisitsParams,
@@ -54,9 +55,9 @@ export type ShlinkApiClient = {
 
   // Tags
 
-  listTags(): Promise<ShlinkTags>;
+  listTags(): Promise<ShlinkTagsList>;
 
-  tagsStats(): Promise<ShlinkTags>;
+  tagsStats(): Promise<ShlinkTagsStatsList>;
 
   deleteTags(tags: string[]): Promise<{ tags: string[] }>;
 

--- a/src/api-contract/errors.ts
+++ b/src/api-contract/errors.ts
@@ -1,23 +1,7 @@
 /**
- * @deprecated Shlink 4.0.0 no longer uses these errors. Use ErrorTypeV3 instead
+ * Possible error types returned by Shlink's API
  */
-export enum ErrorTypeV2 {
-  INVALID_ARGUMENT = 'INVALID_ARGUMENT',
-  INVALID_SHORT_URL_DELETION = 'INVALID_SHORT_URL_DELETION',
-  DOMAIN_NOT_FOUND = 'DOMAIN_NOT_FOUND',
-  FORBIDDEN_OPERATION = 'FORBIDDEN_OPERATION',
-  INVALID_URL = 'INVALID_URL',
-  INVALID_SLUG = 'INVALID_SLUG',
-  INVALID_SHORTCODE = 'INVALID_SHORTCODE',
-  TAG_CONFLICT = 'TAG_CONFLICT',
-  TAG_NOT_FOUND = 'TAG_NOT_FOUND',
-  MERCURE_NOT_CONFIGURED = 'MERCURE_NOT_CONFIGURED',
-  INVALID_AUTHORIZATION = 'INVALID_AUTHORIZATION',
-  INVALID_API_KEY = 'INVALID_API_KEY',
-  NOT_FOUND = 'NOT_FOUND',
-}
-
-export enum ErrorTypeV3 {
+export enum ErrorType {
   INVALID_ARGUMENT = 'https://shlink.io/api/error/invalid-data',
   INVALID_SHORT_URL_DELETION = 'https://shlink.io/api/error/invalid-short-url-deletion',
   DOMAIN_NOT_FOUND = 'https://shlink.io/api/error/domain-not-found',
@@ -35,6 +19,9 @@ export enum ErrorTypeV3 {
   INVALID_URL = 'https://shlink.io/api/error/invalid-url',
 }
 
+/**
+ * Shape of the errors returned by Shlink
+ */
 export type ProblemDetailsError = {
   type: string;
   detail: string;

--- a/src/api-contract/errors.ts
+++ b/src/api-contract/errors.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Shlink 4.0.0 no longer uses these errors. Use ErrorTypeV3 instead
+ */
 export enum ErrorTypeV2 {
   INVALID_ARGUMENT = 'INVALID_ARGUMENT',
   INVALID_SHORT_URL_DELETION = 'INVALID_SHORT_URL_DELETION',
@@ -19,7 +22,6 @@ export enum ErrorTypeV3 {
   INVALID_SHORT_URL_DELETION = 'https://shlink.io/api/error/invalid-short-url-deletion',
   DOMAIN_NOT_FOUND = 'https://shlink.io/api/error/domain-not-found',
   FORBIDDEN_OPERATION = 'https://shlink.io/api/error/forbidden-tag-operation',
-  INVALID_URL = 'https://shlink.io/api/error/invalid-url',
   INVALID_SLUG = 'https://shlink.io/api/error/non-unique-slug',
   INVALID_SHORTCODE = 'https://shlink.io/api/error/short-url-not-found',
   TAG_CONFLICT = 'https://shlink.io/api/error/tag-conflict',
@@ -28,6 +30,9 @@ export enum ErrorTypeV3 {
   INVALID_AUTHORIZATION = 'https://shlink.io/api/error/missing-authentication',
   INVALID_API_KEY = 'https://shlink.io/api/error/invalid-api-key',
   NOT_FOUND = 'https://shlink.io/api/error/not-found',
+
+  /** @deprecated Shlink 4.0.0 no longer validates URLs, so this error will never happen with that version */
+  INVALID_URL = 'https://shlink.io/api/error/invalid-url',
 }
 
 export type ProblemDetailsError = {

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -4,6 +4,9 @@ type Nullable<T> = {
   [P in keyof T]: T[P] | null
 };
 
+/**
+ * @deprecated Shlink 4.0.0 no longer uses this.
+ */
 export type ShlinkDeviceLongUrls = {
   android?: OptionalString;
   ios?: OptionalString;
@@ -20,11 +23,7 @@ export type ShlinkShortUrl = {
   shortCode: string;
   shortUrl: string;
   longUrl: string;
-  /** Optional only before Shlink 3.5.0 */
-  deviceLongUrls?: Required<ShlinkDeviceLongUrls>,
   dateCreated: string;
-  /** @deprecated Use `visitsSummary.total` instead */
-  visitsCount: number;
   /** Optional only before Shlink 3.4.0 */
   visitsSummary?: ShlinkVisitsSummary;
   meta: Required<Nullable<ShlinkShortUrlMeta>>;
@@ -33,29 +32,37 @@ export type ShlinkShortUrl = {
   title?: string | null;
   crawlable?: boolean;
   forwardQuery?: boolean;
+
+  /** @deprecated Use `visitsSummary.total` instead */
+  visitsCount?: number;
+  /** @deprecated Removed in Shlink 4.0.0 */
+  deviceLongUrls?: Required<ShlinkDeviceLongUrls>,
 };
 
 export type ShlinkEditShortUrlData = {
   longUrl?: string;
   title?: string | null;
   tags?: string[];
-  deviceLongUrls?: ShlinkDeviceLongUrls;
   crawlable?: boolean;
   forwardQuery?: boolean;
   validSince?: string | null;
   validUntil?: string | null;
   maxVisits?: number | null;
 
-  /** @deprecated To be removed in Shlink 4.0.0 */
+  /** @deprecated Ignored by Shlink 4.0.0 */
   validateUrl?: boolean;
+  /** @deprecated Ignored by Shlink 4.0.0. Use redirect rules instead */
+  deviceLongUrls?: ShlinkDeviceLongUrls;
 };
 
-export type ShlinkCreateShortUrlData = Omit<ShlinkEditShortUrlData, 'deviceLongUrls'> & {
+export type ShlinkCreateShortUrlData = Omit<ShlinkEditShortUrlData, 'deviceLongUrls' | 'longUrl'> & {
   longUrl: string;
   customSlug?: string;
   shortCodeLength?: number;
   domain?: string;
   findIfExists?: boolean;
+
+  /** @deprecated Ignored by Shlink 4.0.0. Use redirect rules instead */
   deviceLongUrls?: {
     android?: string;
     ios?: string;
@@ -84,10 +91,14 @@ export type ShlinkTagsStats = {
   /** Optional only before Shlink 3.5.0 */
   visitsSummary?: ShlinkVisitsSummary;
 
-  /** @deprecated Use `visitsSummary.total` instead */
-  visitsCount: number;
+  /** @deprecated Not returned by Shlink 4.0.0. Use `visitsSummary.total` instead */
+  visitsCount?: number;
 };
 
+/**
+ * Consolidates ShlinkTagsResponse and ShlinkTagsStatsResponse. Stop doing that
+ * @deprecated
+ */
 export type ShlinkTags = {
   tags: string[];
   stats: ShlinkTagsStats[];
@@ -95,7 +106,8 @@ export type ShlinkTags = {
 
 export type ShlinkTagsResponse = {
   data: string[];
-  /** @deprecated Present only when withStats=true is provided, which is deprecated */
+
+  /** @deprecated Never returned by Shlink 4.0.0, or previous versions when withStats=true is not provided */
   stats?: ShlinkTagsStats[];
 };
 
@@ -159,9 +171,9 @@ export type ShlinkVisitsOverview = {
   orphanVisits?: ShlinkVisitsSummary;
 
   /** @deprecated Use `nonOrphanVisits.total` instead */
-  visitsCount: number;
+  visitsCount?: number;
   /** @deprecated Use `orphanVisits.total` instead */
-  orphanVisitsCount: number;
+  orphanVisitsCount?: number;
 };
 
 export type ShlinkVisitsParams = {

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -95,23 +95,14 @@ export type ShlinkTagsStats = {
   visitsCount?: number;
 };
 
-/**
- * Consolidates ShlinkTagsResponse and ShlinkTagsStatsResponse. Stop doing that
- * @deprecated
- */
-export type ShlinkTags = {
-  tags: string[];
-  stats: ShlinkTagsStats[];
-};
-
-export type ShlinkTagsResponse = { // TODO ShlinkTagsList
+export type ShlinkTagsList = {
   data: string[];
 
-  /** @deprecated Never returned by Shlink 4.0.0, or previous versions when withStats=true is not provided */
+  /** @deprecated Never returned by Shlink 4.0.0 */
   stats?: ShlinkTagsStats[];
 };
 
-export type ShlinkTagsStatsResponse = { // TODO ShlinkTagsStatsList
+export type ShlinkTagsStatsList = {
   data: ShlinkTagsStats[];
 };
 

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -70,7 +70,7 @@ export type ShlinkCreateShortUrlData = Omit<ShlinkEditShortUrlData, 'deviceLongU
   }
 };
 
-export type ShlinkShortUrlsResponse = {
+export type ShlinkShortUrlsList = {
   data: ShlinkShortUrl[];
   pagination: ShlinkPaginator;
 };
@@ -104,14 +104,14 @@ export type ShlinkTags = {
   stats: ShlinkTagsStats[];
 };
 
-export type ShlinkTagsResponse = {
+export type ShlinkTagsResponse = { // TODO ShlinkTagsList
   data: string[];
 
   /** @deprecated Never returned by Shlink 4.0.0, or previous versions when withStats=true is not provided */
   stats?: ShlinkTagsStats[];
 };
 
-export type ShlinkTagsStatsResponse = {
+export type ShlinkTagsStatsResponse = { // TODO ShlinkTagsStatsList
   data: ShlinkTagsStats[];
 };
 
@@ -155,12 +155,12 @@ export type ShlinkOrphanVisit = ShlinkRegularVisit & {
 
 export type ShlinkVisit = ShlinkRegularVisit | ShlinkOrphanVisit;
 
-export type ShlinkVisits = {
+export type ShlinkVisitsList = {
   data: ShlinkVisit[];
   pagination: ShlinkPaginator;
 };
 
-export type ShlinkDeleteVisitsResponse = {
+export type ShlinkDeleteVisitsResult = {
   deletedVisits: number;
 };
 
@@ -204,7 +204,7 @@ export type ShlinkDomain = {
   redirects: ShlinkDomainRedirects;
 };
 
-export type ShlinkDomainsResponse = {
+export type ShlinkDomainsList = {
   data: ShlinkDomain[];
   defaultRedirects: ShlinkDomainRedirects;
 };

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -12,9 +12,8 @@ import type {
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
   ShlinkShortUrlVisitsParams,
-  ShlinkTags,
-  ShlinkTagsResponse,
-  ShlinkTagsStatsResponse,
+  ShlinkTagsList,
+  ShlinkTagsStatsList,
   ShlinkVisitsList,
   ShlinkVisitsOverview,
   ShlinkVisitsParams,
@@ -133,16 +132,15 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   // Tags
 
-  public async listTags(): Promise<ShlinkTags> {
-    return this.performRequest<{ tags: ShlinkTagsResponse }>({ url: '/tags', query: { withStats: 'true' } })
-      .then(({ tags }) => tags)
-      .then(({ data, stats = [] }) => ({ tags: data, stats }));
+  public async listTags(): Promise<ShlinkTagsList> {
+    return this.performRequest<{ tags: ShlinkTagsList }>({
+      url: '/tags',
+      query: { withStats: 'true' }, // FIXME Remove this query param once Shlink 3.0 is no longer supported
+    }).then(({ tags }) => tags);
   }
 
-  public async tagsStats(): Promise<ShlinkTags> {
-    return this.performRequest<{ tags: ShlinkTagsStatsResponse }>({ url: '/tags/stats' })
-      .then(({ tags }) => tags)
-      .then(({ data }) => ({ tags: data.map(({ tag }) => tag), stats: data }));
+  public async tagsStats(): Promise<ShlinkTagsStatsList> {
+    return this.performRequest<{ tags: ShlinkTagsStatsList }>({ url: '/tags/stats' }).then(({ tags }) => tags);
   }
 
   public async deleteTags(tags: string[]): Promise<{ tags: string[] }> {

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -3,12 +3,8 @@ import type {
   ShlinkShortUrlsListParams,
   ShlinkShortUrlsOrder,
 } from '../api-contract';
-import {
-  ErrorTypeV2,
-  ErrorTypeV3,
-} from '../api-contract';
 
-export type ApiVersion = 2 | 3;
+export type ApiVersion = 3;
 
 export const buildShlinkBaseUrl = (url: string, version: ApiVersion) => `${url}/rest/v${version}`;
 
@@ -24,14 +20,6 @@ export const normalizeListParams = (
   excludePastValidUntil: excludePastValidUntil === true ? 'true' : undefined,
   orderBy: shortUrlsOrderToString(orderBy),
 });
-
-export const isRegularNotFound = (error: unknown): boolean => {
-  if (error === null || !(typeof error === 'object' && 'type' in error && 'status' in error)) {
-    return false;
-  }
-
-  return (error.type === ErrorTypeV2.NOT_FOUND || error.type === ErrorTypeV3.NOT_FOUND) && error.status === 404;
-};
 
 export const replaceAuthorityFromUri = (uri: string, newAuthority: string): string => {
   const [schema, rest] = uri.split('://');

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -5,10 +5,9 @@ import type {
   ShlinkDomain,
   ShlinkShortUrl,
   ShlinkShortUrlsOrder,
-  ShlinkVisits,
+  ShlinkVisitsList,
   ShlinkVisitsOverview,
 } from '../../src/api-contract';
-import { ErrorTypeV2, ErrorTypeV3 } from '../../src/api-contract';
 
 describe('ShlinkApiClient', () => {
   const jsonRequest = vi.fn().mockResolvedValue({});
@@ -354,7 +353,7 @@ describe('ShlinkApiClient', () => {
 
   describe('getOrphanVisits', () => {
     it('returns orphan visits', async () => {
-      jsonRequest.mockResolvedValue({ visits: fromPartial<ShlinkVisits>({ data: [] }) });
+      jsonRequest.mockResolvedValue({ visits: fromPartial<ShlinkVisitsList>({ data: [] }) });
 
       const result = await apiClient.getOrphanVisits();
 
@@ -380,7 +379,7 @@ describe('ShlinkApiClient', () => {
 
   describe('getNonOrphanVisits', () => {
     it('returns non-orphan visits', async () => {
-      jsonRequest.mockResolvedValue({ visits: fromPartial<ShlinkVisits>({ data: [] }) });
+      jsonRequest.mockResolvedValue({ visits: fromPartial<ShlinkVisitsList>({ data: [] }) });
 
       const result = await apiClient.getNonOrphanVisits();
 
@@ -398,22 +397,6 @@ describe('ShlinkApiClient', () => {
 
       expect(jsonRequest).toHaveBeenCalled();
       expect(result).toEqual(resp);
-    });
-
-    it.each([
-      ['NOT_FOUND'],
-      [ErrorTypeV2.NOT_FOUND],
-      [ErrorTypeV3.NOT_FOUND],
-    ])('retries request if API version is not supported', async (type) => {
-      jsonRequest
-        .mockRejectedValueOnce({ type, detail: 'detail', title: 'title', status: 404 })
-        .mockResolvedValue({});
-
-      await apiClient.editDomainRedirects({ domain: 'foo' });
-
-      expect(jsonRequest).toHaveBeenCalledTimes(2);
-      expect(jsonRequest).toHaveBeenNthCalledWith(1, expect.stringContaining('/v3/'), expect.anything());
-      expect(jsonRequest).toHaveBeenNthCalledWith(2, expect.stringContaining('/v2/'), expect.anything());
     });
   });
 });

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -217,7 +217,7 @@ describe('ShlinkApiClient', () => {
 
       const result = await apiClient.listTags();
 
-      expect(result).toEqual({ tags: expectedTags, stats: [] });
+      expect(result).toEqual({ data: expectedTags });
       expect(jsonRequest).toHaveBeenCalledWith(
         expect.stringContaining('/tags'),
         expect.objectContaining({ method: 'GET' }),
@@ -227,8 +227,8 @@ describe('ShlinkApiClient', () => {
 
   describe('tagsStats', () => {
     it('can use /tags/stats endpoint', async () => {
-      const expectedTags = ['foo', 'bar'];
-      const expectedStats = expectedTags.map((tag) => ({ tag, shortUrlsCount: 10, visitsCount: 10 }));
+      const tags = ['foo', 'bar'];
+      const expectedStats = tags.map((tag) => ({ tag, shortUrlsCount: 10, visitsCount: 10 }));
 
       jsonRequest.mockResolvedValue({
         tags: {
@@ -238,7 +238,7 @@ describe('ShlinkApiClient', () => {
 
       const result = await apiClient.tagsStats();
 
-      expect({ tags: expectedTags, stats: expectedStats }).toEqual(result);
+      expect({ data: expectedStats }).toEqual(result);
       expect(jsonRequest).toHaveBeenCalledWith(
         expect.stringContaining('/tags/stats'),
         expect.objectContaining({ method: 'GET' }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       include: [
         'src/**/*.ts',
         '!src/index.ts',
+        '!src/api-contract/*',
       ],
       reporter: ['text', 'text-summary', 'clover', 'html'],
 


### PR DESCRIPTION
Closes #74 

Closes #22 

Part of #72 

This PR renames and consolidates many API contract types, to make it more consistent, and adhere to the changes from Shlink 4.0.0.

It also drops supports for Shlink older than v3.3.0, removing the need to take the API v2 into consideration.