### PR TITLE
Allow type param to be passed to getOrphanVisits()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
-* *Nothing*
+* [#72](https://github.com/shlinkio/shlink-js-sdk/issues/72) Add support for Shlink 4.0.0
+
+  * Add `type` param to `ShlinkApiClient.getOrphanVisits`.
 
 ### Changed
 * Update dependencies.

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -7,6 +7,7 @@ import type {
   ShlinkEditShortUrlData,
   ShlinkHealth,
   ShlinkMercureInfo,
+  ShlinkOrphanVisitsParams,
   ShlinkShortUrl,
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
@@ -45,7 +46,7 @@ export type ShlinkApiClient = {
 
   getDomainVisits(domain: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
 
-  getOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+  getOrphanVisits(params?: ShlinkOrphanVisitsParams): Promise<ShlinkVisitsList>;
 
   getNonOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
 

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -179,6 +179,11 @@ export type ShlinkShortUrlVisitsParams = ShlinkVisitsParams & {
   domain?: string | null;
 };
 
+export type ShlinkOrphanVisitsParams = ShlinkVisitsParams & {
+  /** Ignored by Shlink older than v4.0.0 */
+  type?: ShlinkOrphanVisitType;
+};
+
 export type ShlinkDomainRedirects = {
   baseUrlRedirect: string | null;
   regular404Redirect: string | null;

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -8,6 +8,7 @@ import type {
   ShlinkEditShortUrlData,
   ShlinkHealth,
   ShlinkMercureInfo,
+  ShlinkOrphanVisitsParams,
   ShlinkShortUrl,
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
@@ -94,29 +95,27 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   }
 
   public async getShortUrlVisits(shortCode: string, params?: ShlinkShortUrlVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performRequest<{ visits: ShlinkVisitsList }>({ url: `/short-urls/${shortCode}/visits`, query: params })
-      .then(({ visits }) => visits);
+    return this.performVisitsRequest({ url: `/short-urls/${shortCode}/visits`, query: params });
   }
 
   public async getTagVisits(tag: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performRequest<{ visits: ShlinkVisitsList }>({ url: `/tags/${tag}/visits`, query: params })
-      .then(({ visits }) => visits);
+    return this.performVisitsRequest({ url: `/tags/${tag}/visits`, query: params });
   }
 
   public async getDomainVisits(domain: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performRequest<{ visits: ShlinkVisitsList }>({ url: `/domains/${domain}/visits`, query: params })
-      .then(({ visits }) => visits);
+    return this.performVisitsRequest({ url: `/domains/${domain}/visits`, query: params });
   }
 
-  public async getOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performRequest<{ visits: ShlinkVisitsList }>({ url: '/visits/orphan', query: params }).then(
-      ({ visits }) => visits,
-    );
+  public async getOrphanVisits(params?: ShlinkOrphanVisitsParams): Promise<ShlinkVisitsList> {
+    return this.performVisitsRequest({ url: '/visits/orphan', query: params });
   }
 
   public async getNonOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performRequest<{ visits: ShlinkVisitsList }>({ url: '/visits/non-orphan', query: params })
-      .then(({ visits }) => visits);
+    return this.performVisitsRequest({ url: '/visits/non-orphan', query: params });
+  }
+
+  private async performVisitsRequest(options: ShlinkRequestOptions): Promise<ShlinkVisitsList> {
+    return this.performRequest<{ visits: ShlinkVisitsList }>(options).then(({ visits }) => visits);
   }
 
   public async deleteShortUrlVisits(shortCode: string, domain?: string | null): Promise<ShlinkDeleteVisitsResult> {


### PR DESCRIPTION
Part of #72 

Add `type` param to `ShlinkApiClient.getOrphanVisits`