### PR TITLE
Feature/redirect rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [1.0.0] - 2024-03-05
 ### Added
 * [#72](https://github.com/shlinkio/shlink-js-sdk/issues/72) Add support for Shlink 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 * [#72](https://github.com/shlinkio/shlink-js-sdk/issues/72) Add support for Shlink 4.0.0
 
+  * Add support to list and set short URL redirect conditions.
   * Add `type` param to `ShlinkApiClient.getOrphanVisits`.
 
 ### Changed

--- a/dev/index.mjs
+++ b/dev/index.mjs
@@ -13,7 +13,7 @@ import { NodeHttpClient } from '../dist/node.js';
       baseUrl,
       apiKey,
     });
-    console.log('Success:', await apiClient.deleteShortUrlVisits('nieRB'));
+    console.log('Success:', await apiClient.getShortUrlRedirectRules('sNvEk'));
   } catch (e) {
     console.error('Error:', e);
   }

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -8,6 +8,8 @@ import type {
   ShlinkHealth,
   ShlinkMercureInfo,
   ShlinkOrphanVisitsParams,
+  ShlinkRedirectRulesList,
+  ShlinkSetRedirectRulesData,
   ShlinkShortUrl,
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
@@ -35,6 +37,16 @@ export type ShlinkApiClient = {
     domain: string | null | undefined,
     data: ShlinkEditShortUrlData,
   ): Promise<ShlinkShortUrl>;
+
+  // Short URL redirect rules
+
+  getShortUrlRedirectRules(shortCode: string, domain?: string | null): Promise<ShlinkRedirectRulesList>;
+
+  setShortUrlRedirectRules(
+    shortCode: string,
+    domain: string | null | undefined,
+    data: ShlinkSetRedirectRulesData,
+  ): Promise<ShlinkRedirectRulesList>;
 
   // Visits
 

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -224,3 +224,29 @@ export type ShlinkShortUrlsListParams = {
   excludeMaxVisitsReached?: boolean;
   excludePastValidUntil?: boolean;
 };
+
+export type ShlinkRedirectConditionType = 'device' | 'language' | 'query-param';
+
+export type ShlinkRedirectCondition = {
+  type: ShlinkRedirectConditionType;
+  matchKey: string | null;
+  matchValue: string;
+};
+
+export type ShlinkRedirectRuleData = {
+  longUrl: string;
+  conditions: ShlinkRedirectCondition[];
+};
+
+export type ShlinkRedirectRule = ShlinkRedirectRuleData & {
+  priority: number;
+};
+
+export type ShlinkRedirectRulesList = {
+  defaultLongUrl: string;
+  redirectRules: ShlinkRedirectRule[];
+};
+
+export type ShlinkSetRedirectRulesData = {
+  redirectRules: ShlinkRedirectRuleData[];
+};

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -224,10 +224,3 @@ export type ShlinkShortUrlsListParams = {
   excludeMaxVisitsReached?: boolean;
   excludePastValidUntil?: boolean;
 };
-
-export type ShlinkShortUrlsListNormalizedParams =
-  Omit<ShlinkShortUrlsListParams, 'orderBy' | 'excludeMaxVisitsReached' | 'excludePastValidUntil'> & {
-    orderBy?: string;
-    excludeMaxVisitsReached?: 'true';
-    excludePastValidUntil?: 'true';
-  };

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -9,6 +9,8 @@ import type {
   ShlinkHealth,
   ShlinkMercureInfo,
   ShlinkOrphanVisitsParams,
+  ShlinkRedirectRulesList,
+  ShlinkSetRedirectRulesData,
   ShlinkShortUrl,
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
@@ -85,6 +87,24 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   ): Promise<ShlinkShortUrl> {
     return this.performRequest<ShlinkShortUrl>(
       { url: `/short-urls/${shortCode}`, method: 'PATCH', query: { domain }, body: data },
+    );
+  }
+
+  // Short URL redirect rules
+
+  public async getShortUrlRedirectRules(shortCode: string, domain?: string | null): Promise<ShlinkRedirectRulesList> {
+    return this.performRequest<ShlinkRedirectRulesList>(
+      { url: `/short-urls/${shortCode}/redirect-rules`, method: 'GET', query: { domain } },
+    );
+  }
+
+  public async setShortUrlRedirectRules(
+    shortCode: string,
+    domain: string | null | undefined,
+    data: ShlinkSetRedirectRulesData,
+  ): Promise<ShlinkRedirectRulesList> {
+    return this.performRequest<ShlinkRedirectRulesList>(
+      { url: `/short-urls/${shortCode}/redirect-rules`, method: 'POST', query: { domain }, body: data },
     );
   }
 

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,8 +1,4 @@
-import type {
-  ShlinkShortUrlsListNormalizedParams,
-  ShlinkShortUrlsListParams,
-  ShlinkShortUrlsOrder,
-} from '../api-contract';
+import type { ShlinkShortUrlsListParams, ShlinkShortUrlsOrder } from '../api-contract';
 
 export type ApiVersion = 3;
 
@@ -11,6 +7,13 @@ export const buildShlinkBaseUrl = (url: string, version: ApiVersion) => `${url}/
 const shortUrlsOrderToString = (order: ShlinkShortUrlsOrder): string | undefined => (
   order.dir ? `${order.field}-${order.dir}` : undefined
 );
+
+type ShlinkShortUrlsListNormalizedParams =
+  Omit<ShlinkShortUrlsListParams, 'orderBy' | 'excludeMaxVisitsReached' | 'excludePastValidUntil'> & {
+    orderBy?: string;
+    excludeMaxVisitsReached?: 'true';
+    excludePastValidUntil?: 'true';
+  };
 
 export const normalizeListParams = (
   { orderBy = {}, excludeMaxVisitsReached, excludePastValidUntil, ...rest }: ShlinkShortUrlsListParams,

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -3,6 +3,8 @@ import type { HttpClient } from '../../src';
 import { ShlinkApiClient } from '../../src';
 import type {
   ShlinkDomain,
+  ShlinkRedirectRulesList,
+  ShlinkSetRedirectRulesData,
   ShlinkShortUrl,
   ShlinkShortUrlsOrder,
   ShlinkVisitsList,
@@ -396,6 +398,53 @@ describe('ShlinkApiClient', () => {
       const result = await apiClient.editDomainRedirects({ domain: 'foo' });
 
       expect(jsonRequest).toHaveBeenCalled();
+      expect(result).toEqual(resp);
+    });
+  });
+
+  describe('getShortUrlRedirectRules', () => {
+    it.each([
+      ['the_domain', '?domain=the_domain'],
+      [null, ''],
+      [undefined, ''],
+    ])('returns the redirect rules', async (domain, expectedQuery) => {
+      const resp: ShlinkRedirectRulesList = {
+        defaultLongUrl: 'foo',
+        redirectRules: [],
+      };
+      jsonRequest.mockResolvedValue(resp);
+
+      const result = await apiClient.getShortUrlRedirectRules('foo', domain);
+
+      expect(jsonRequest).toHaveBeenCalledWith(
+        expect.stringContaining(`/short-urls/foo/redirect-rules${expectedQuery}`),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toEqual(resp);
+    });
+  });
+
+  describe('setShortUrlRedirectRules', () => {
+    it.each([
+      ['the_domain', '?domain=the_domain'],
+      [null, ''],
+      [undefined, ''],
+    ])('sets redirect rules', async (domain, expectedQuery) => {
+      const resp: ShlinkRedirectRulesList = {
+        defaultLongUrl: 'foo',
+        redirectRules: [],
+      };
+      const data: ShlinkSetRedirectRulesData = {
+        redirectRules: [],
+      };
+      jsonRequest.mockResolvedValue(resp);
+
+      const result = await apiClient.setShortUrlRedirectRules('foo', domain, data);
+
+      expect(jsonRequest).toHaveBeenCalledWith(
+        expect.stringContaining(`/short-urls/foo/redirect-rules${expectedQuery}`),
+        expect.objectContaining({ method: 'POST', body: JSON.stringify(data) }),
+      );
       expect(result).toEqual(resp);
     });
   });


### PR DESCRIPTION
Closes #72 

Add support for short URL redirect rules endpoints.

* https://api-spec.shlink.io/#/Redirect%20rules/listShortUrlRedirectRules
* https://api-spec.shlink.io/#/Redirect%20rules/setShortUrlRedirectRules