### PR TITLE
Allow an AbortSignal to be provided to ShlinkApiClient methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#8](https://github.com/shlinkio/shlink-js-sdk/issues/8) Allow an `AbortSignal` to be provided as the last optional argument to all public `ShlinkApiClient` methods.
+
+  This will let consumers control if a request should be aborted, via `AbortController`.
+
+### Changed
+* Rearrange `exports` order, as suggested by vitest.
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [1.3.0] - 2024-11-25
 ### Added
 * Add support for `geolocation-country-code` and `geolocation-city-name` redirect condition types.

--- a/package.json
+++ b/package.json
@@ -10,24 +10,24 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.js"
     },
     "./api-contract": {
-      "import": "./dist/api-contract.js",
+      "types": "./dist/api-contract.d.ts",
       "require": "./dist/api-contract.cjs",
-      "types": "./dist/api-contract.d.ts"
+      "import": "./dist/api-contract.js"
     },
     "./browser": {
-      "import": "./dist/browser.js",
+      "types": "./dist/browser.d.ts",
       "require": "./dist/browser.cjs",
-      "types": "./dist/browser.d.ts"
+      "import": "./dist/browser.js"
     },
     "./node": {
-      "import": "./dist/node.js",
+      "types": "./dist/node.d.ts",
       "require": "./dist/node.cjs",
-      "types": "./dist/node.d.ts"
+      "import": "./dist/node.js"
     },
     "./package.json": "./package.json"
   },

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -24,67 +24,81 @@ import type {
 export type ShlinkApiClient = {
   // Short URLs
 
-  listShortUrls(params?: ShlinkShortUrlsListParams): Promise<ShlinkShortUrlsList>;
+  listShortUrls(params?: ShlinkShortUrlsListParams, signal?: AbortSignal): Promise<ShlinkShortUrlsList>;
 
-  createShortUrl(options: ShlinkCreateShortUrlData): Promise<ShlinkShortUrl>;
+  createShortUrl(options: ShlinkCreateShortUrlData, signal?: AbortSignal): Promise<ShlinkShortUrl>;
 
-  getShortUrl(shortCode: string, domain?: string | null): Promise<ShlinkShortUrl>;
+  getShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<ShlinkShortUrl>;
 
-  deleteShortUrl(shortCode: string, domain?: string | null): Promise<void>;
+  deleteShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<void>;
 
   updateShortUrl(
     shortCode: string,
     domain: string | null | undefined,
     data: ShlinkEditShortUrlData,
+    signal?: AbortSignal,
   ): Promise<ShlinkShortUrl>;
 
   // Short URL redirect rules
 
-  getShortUrlRedirectRules(shortCode: string, domain?: string | null): Promise<ShlinkRedirectRulesList>;
+  getShortUrlRedirectRules(
+    shortCode: string,
+    domain?: string | null,
+    signal?: AbortSignal,
+  ): Promise<ShlinkRedirectRulesList>;
 
   setShortUrlRedirectRules(
     shortCode: string,
     domain: string | null | undefined,
     data: ShlinkSetRedirectRulesData,
+    signal?: AbortSignal,
   ): Promise<ShlinkRedirectRulesList>;
 
   // Visits
 
-  getVisitsOverview(): Promise<ShlinkVisitsOverview>;
+  getVisitsOverview(signal?: AbortSignal): Promise<ShlinkVisitsOverview>;
 
-  getShortUrlVisits(shortCode: string, params?: ShlinkShortUrlVisitsParams): Promise<ShlinkVisitsList>;
+  getShortUrlVisits(
+    shortCode: string,
+    params?: ShlinkShortUrlVisitsParams,
+    signal?: AbortSignal,
+  ): Promise<ShlinkVisitsList>;
 
-  getTagVisits(tag: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+  getTagVisits(tag: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
 
-  getDomainVisits(domain: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+  getDomainVisits(domain: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
 
-  getOrphanVisits(params?: ShlinkOrphanVisitsParams): Promise<ShlinkVisitsList>;
+  getOrphanVisits(params?: ShlinkOrphanVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
 
-  getNonOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList>;
+  getNonOrphanVisits(params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
 
-  deleteShortUrlVisits(shortCode: string, domain?: string | null): Promise<ShlinkDeleteVisitsResult>;
+  deleteShortUrlVisits(
+    shortCode: string,
+    domain?: string | null,
+    signal?: AbortSignal,
+  ): Promise<ShlinkDeleteVisitsResult>;
 
-  deleteOrphanVisits(): Promise<ShlinkDeleteVisitsResult>;
+  deleteOrphanVisits(signal?: AbortSignal): Promise<ShlinkDeleteVisitsResult>;
 
   // Tags
 
-  listTags(): Promise<ShlinkTagsList>;
+  listTags(signal?: AbortSignal): Promise<ShlinkTagsList>;
 
-  tagsStats(): Promise<ShlinkTagsStatsList>;
+  tagsStats(signal?: AbortSignal): Promise<ShlinkTagsStatsList>;
 
-  deleteTags(tags: string[]): Promise<{ tags: string[] }>;
+  deleteTags(tags: string[], signal?: AbortSignal): Promise<{ tags: string[] }>;
 
-  editTag(oldName: string, newName: string): Promise<{ oldName: string; newName: string }>;
+  editTag(oldName: string, newName: string, signal?: AbortSignal): Promise<{ oldName: string; newName: string }>;
 
   // Domains
 
-  listDomains(): Promise<ShlinkDomainsList>;
+  listDomains(signal?: AbortSignal): Promise<ShlinkDomainsList>;
 
-  editDomainRedirects(domainRedirects: ShlinkEditDomainRedirects): Promise<ShlinkDomainRedirects>;
+  editDomainRedirects(domainRedirects: ShlinkEditDomainRedirects, signal?: AbortSignal): Promise<ShlinkDomainRedirects>;
 
   // Misc
 
-  health(authority?: string): Promise<ShlinkHealth>;
+  health(authority?: string, signal?: AbortSignal): Promise<ShlinkHealth>;
 
-  mercureInfo(): Promise<ShlinkMercureInfo>;
+  mercureInfo(signal?: AbortSignal): Promise<ShlinkMercureInfo>;
 };

--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -2,6 +2,7 @@ export type RequestOptions = {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: string;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 };
 
 export type HttpClient = {

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -237,6 +237,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     query = {},
     body,
     domain,
+    signal,
   }: ShlinkRequestOptions): [string, RequestOptions] {
     const normalizedQuery = queryParamsToString(query);
     const stringifiedQuery = !normalizedQuery ? '' : `?${normalizedQuery}`;
@@ -246,6 +247,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
       method,
       body: body && JSON.stringify(body),
       headers: { 'X-Api-Key': this.serverInfo.apiKey },
+      signal,
     }];
   }
 }

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -36,6 +36,7 @@ type ShlinkRequestOptions = {
   query?: object;
   body?: object;
   domain?: string;
+  signal?: AbortSignal;
 };
 
 export type ServerInfo = {
@@ -55,13 +56,16 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   // Short URLs
 
-  public async listShortUrls(params: ShlinkShortUrlsListParams = {}): Promise<ShlinkShortUrlsList> {
+  public async listShortUrls(
+    params: ShlinkShortUrlsListParams = {},
+    signal?: AbortSignal,
+  ): Promise<ShlinkShortUrlsList> {
     return this.performRequest<{ shortUrls: ShlinkShortUrlsList }>(
-      { url: '/short-urls', query: normalizeListParams(params) },
+      { url: '/short-urls', query: normalizeListParams(params), signal },
     ).then(({ shortUrls }) => shortUrls);
   }
 
-  public async createShortUrl(options: ShlinkCreateShortUrlData): Promise<ShlinkShortUrl> {
+  public async createShortUrl(options: ShlinkCreateShortUrlData, signal?: AbortSignal): Promise<ShlinkShortUrl> {
     const body = Object.entries(options).reduce<any>((obj, [key, value]) => {
       if (value) {
 
@@ -69,32 +73,37 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
       }
       return obj;
     }, {});
-    return this.performRequest<ShlinkShortUrl>({ url: '/short-urls', method: 'POST', body });
+    return this.performRequest<ShlinkShortUrl>({ url: '/short-urls', method: 'POST', body, signal });
   }
 
-  public async getShortUrl(shortCode: string, domain?: string | null): Promise<ShlinkShortUrl> {
-    return this.performRequest<ShlinkShortUrl>({ url: `/short-urls/${shortCode}`, query: { domain } });
+  public async getShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<ShlinkShortUrl> {
+    return this.performRequest<ShlinkShortUrl>({ url: `/short-urls/${shortCode}`, query: { domain }, signal });
   }
 
-  public async deleteShortUrl(shortCode: string, domain?: string | null | undefined): Promise<void> {
-    return this.performEmptyRequest({ url: `/short-urls/${shortCode}`, method: 'DELETE', query: { domain } });
+  public async deleteShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<void> {
+    return this.performEmptyRequest({ url: `/short-urls/${shortCode}`, method: 'DELETE', query: { domain }, signal });
   }
 
   public async updateShortUrl(
     shortCode: string,
     domain: string | null | undefined,
     data: ShlinkEditShortUrlData,
+    signal?: AbortSignal,
   ): Promise<ShlinkShortUrl> {
     return this.performRequest<ShlinkShortUrl>(
-      { url: `/short-urls/${shortCode}`, method: 'PATCH', query: { domain }, body: data },
+      { url: `/short-urls/${shortCode}`, method: 'PATCH', query: { domain }, body: data, signal },
     );
   }
 
   // Short URL redirect rules
 
-  public async getShortUrlRedirectRules(shortCode: string, domain?: string | null): Promise<ShlinkRedirectRulesList> {
+  public async getShortUrlRedirectRules(
+    shortCode: string,
+    domain?: string | null,
+    signal?: AbortSignal,
+  ): Promise<ShlinkRedirectRulesList> {
     return this.performRequest<ShlinkRedirectRulesList>(
-      { url: `/short-urls/${shortCode}/redirect-rules`, method: 'GET', query: { domain } },
+      { url: `/short-urls/${shortCode}/redirect-rules`, method: 'GET', query: { domain }, signal },
     );
   }
 
@@ -102,97 +111,116 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     shortCode: string,
     domain: string | null | undefined,
     data: ShlinkSetRedirectRulesData,
+    signal?: AbortSignal,
   ): Promise<ShlinkRedirectRulesList> {
     return this.performRequest<ShlinkRedirectRulesList>(
-      { url: `/short-urls/${shortCode}/redirect-rules`, method: 'POST', query: { domain }, body: data },
+      { url: `/short-urls/${shortCode}/redirect-rules`, method: 'POST', query: { domain }, body: data, signal },
     );
   }
 
   // Visits
 
-  public async getVisitsOverview(): Promise<ShlinkVisitsOverview> {
-    return this.performRequest<{ visits: ShlinkVisitsOverview }>({ url: '/visits' }).then(({ visits }) => visits);
+  public async getVisitsOverview(signal?: AbortSignal): Promise<ShlinkVisitsOverview> {
+    return this.performRequest<{ visits: ShlinkVisitsOverview }>({ url: '/visits', signal }).then(
+      ({ visits }) => visits,
+    );
   }
 
-  public async getShortUrlVisits(shortCode: string, params?: ShlinkShortUrlVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performVisitsRequest({ url: `/short-urls/${shortCode}/visits`, query: params });
+  public async getShortUrlVisits(
+    shortCode: string,
+    params?: ShlinkShortUrlVisitsParams,
+    signal?: AbortSignal,
+  ): Promise<ShlinkVisitsList> {
+    return this.performVisitsRequest({ url: `/short-urls/${shortCode}/visits`, query: params, signal });
   }
 
-  public async getTagVisits(tag: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performVisitsRequest({ url: `/tags/${tag}/visits`, query: params });
+  public async getTagVisits(tag: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
+    return this.performVisitsRequest({ url: `/tags/${tag}/visits`, query: params, signal });
   }
 
-  public async getDomainVisits(domain: string, params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performVisitsRequest({ url: `/domains/${domain}/visits`, query: params });
+  public async getDomainVisits(
+    domain: string,
+    params?: ShlinkVisitsParams,
+    signal?: AbortSignal,
+  ): Promise<ShlinkVisitsList> {
+    return this.performVisitsRequest({ url: `/domains/${domain}/visits`, query: params, signal });
   }
 
-  public async getOrphanVisits(params?: ShlinkOrphanVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performVisitsRequest({ url: '/visits/orphan', query: params });
+  public async getOrphanVisits(params?: ShlinkOrphanVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
+    return this.performVisitsRequest({ url: '/visits/orphan', query: params, signal });
   }
 
-  public async getNonOrphanVisits(params?: ShlinkVisitsParams): Promise<ShlinkVisitsList> {
-    return this.performVisitsRequest({ url: '/visits/non-orphan', query: params });
+  public async getNonOrphanVisits(params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
+    return this.performVisitsRequest({ url: '/visits/non-orphan', query: params, signal });
   }
 
   private async performVisitsRequest(options: ShlinkRequestOptions): Promise<ShlinkVisitsList> {
     return this.performRequest<{ visits: ShlinkVisitsList }>(options).then(({ visits }) => visits);
   }
 
-  public async deleteShortUrlVisits(shortCode: string, domain?: string | null): Promise<ShlinkDeleteVisitsResult> {
+  public async deleteShortUrlVisits(
+    shortCode: string,
+    domain?: string | null,
+    signal?: AbortSignal,
+  ): Promise<ShlinkDeleteVisitsResult> {
     const query = domain ? { domain } : undefined;
     return this.performRequest<ShlinkDeleteVisitsResult>(
-      { method: 'DELETE', url: `/short-urls/${shortCode}/visits`, query },
+      { method: 'DELETE', url: `/short-urls/${shortCode}/visits`, query, signal },
     );
   }
 
-  public async deleteOrphanVisits(): Promise<ShlinkDeleteVisitsResult> {
-    return this.performRequest<ShlinkDeleteVisitsResult>({ method: 'DELETE', url: '/visits/orphan' });
+  public async deleteOrphanVisits(signal?: AbortSignal): Promise<ShlinkDeleteVisitsResult> {
+    return this.performRequest<ShlinkDeleteVisitsResult>({ method: 'DELETE', url: '/visits/orphan', signal });
   }
 
   // Tags
 
-  public async listTags(): Promise<ShlinkTagsList> {
-    return this.performRequest<{ tags: ShlinkTagsList }>({
-      url: '/tags',
-      query: { withStats: 'true' }, // FIXME Remove this query param once Shlink 3.0 is no longer supported
-    }).then(({ tags }) => tags);
+  public async listTags(signal?: AbortSignal): Promise<ShlinkTagsList> {
+    return this.performRequest<{ tags: ShlinkTagsList }>({ url: '/tags', signal }).then(({ tags }) => tags);
   }
 
-  public async tagsStats(): Promise<ShlinkTagsStatsList> {
-    return this.performRequest<{ tags: ShlinkTagsStatsList }>({ url: '/tags/stats' }).then(({ tags }) => tags);
+  public async tagsStats(signal?: AbortSignal): Promise<ShlinkTagsStatsList> {
+    return this.performRequest<{ tags: ShlinkTagsStatsList }>({ url: '/tags/stats', signal }).then(({ tags }) => tags);
   }
 
-  public async deleteTags(tags: string[]): Promise<{ tags: string[] }> {
-    return this.performEmptyRequest({ url: '/tags', method: 'DELETE', query: { tags } }).then(() => ({ tags }));
+  public async deleteTags(tags: string[], signal?: AbortSignal): Promise<{ tags: string[] }> {
+    return this.performEmptyRequest({ url: '/tags', method: 'DELETE', query: { tags }, signal }).then(() => ({ tags }));
   }
 
-  public async editTag(oldName: string, newName: string): Promise<{ oldName: string; newName: string }> {
-    return this.performEmptyRequest({ url: '/tags', method: 'PUT', body: { oldName, newName } })
+  public async editTag(
+    oldName: string,
+    newName: string,
+    signal?: AbortSignal,
+  ): Promise<{ oldName: string; newName: string }> {
+    return this.performEmptyRequest({ url: '/tags', method: 'PUT', body: { oldName, newName }, signal })
       .then(() => ({ oldName, newName }));
   }
 
   // Domains
 
-  public async listDomains(): Promise<ShlinkDomainsList> {
-    return this.performRequest<{ domains: ShlinkDomainsList }>({ url: '/domains' }).then(({ domains }) => domains);
+  public async listDomains(signal?: AbortSignal): Promise<ShlinkDomainsList> {
+    return this.performRequest<{ domains: ShlinkDomainsList }>({ url: '/domains', signal }).then(
+      ({ domains }) => domains,
+    );
   }
 
   public async editDomainRedirects(
     domainRedirects: ShlinkEditDomainRedirects,
+    signal?: AbortSignal,
   ): Promise<ShlinkDomainRedirects> {
     return this.performRequest<ShlinkDomainRedirects>(
-      { url: '/domains/redirects', method: 'PATCH', body: domainRedirects },
+      { url: '/domains/redirects', method: 'PATCH', body: domainRedirects, signal },
     );
   }
 
   // Misc
 
-  public async health(domain?: string): Promise<ShlinkHealth> {
-    return this.performRequest<ShlinkHealth>({ url: '/health', domain });
+  public async health(domain?: string, signal?: AbortSignal): Promise<ShlinkHealth> {
+    return this.performRequest<ShlinkHealth>({ url: '/health', domain, signal });
   }
 
-  public async mercureInfo(): Promise<ShlinkMercureInfo> {
-    return this.performRequest<ShlinkMercureInfo>({ url: '/mercure-info' });
+  public async mercureInfo(signal?: AbortSignal): Promise<ShlinkMercureInfo> {
+    return this.performRequest<ShlinkMercureInfo>({ url: '/mercure-info', signal });
   }
 
   private async performRequest<T>(requestOptions: ShlinkRequestOptions): Promise<T> {

--- a/src/browser/FetchHttpClient.ts
+++ b/src/browser/FetchHttpClient.ts
@@ -24,22 +24,20 @@ export class FetchHttpClient implements HttpClient {
   constructor(private readonly fetch: Fetch = window.fetch.bind(window)) {}
 
   public async jsonRequest<T>(url: string, options?: RequestOptions): Promise<T> {
-    return this.fetch(url, withJsonContentType(options)).then(async (resp) => {
-      const json = await resp.json();
+    const resp = await this.fetch(url, withJsonContentType(options));
+    const json = await resp.json();
 
-      if (!resp.ok) {
-        throw json;
-      }
+    if (!resp.ok) {
+      throw json;
+    }
 
-      return json as T;
-    });
+    return json as T;
   }
 
   async emptyRequest(url: string, options?: RequestOptions): Promise<void> {
-    return this.fetch(url, withJsonContentType(options)).then(async (resp) => {
-      if (!resp.ok) {
-        throw await resp.json();
-      }
-    });
+    const resp = await this.fetch(url, withJsonContentType(options));
+    if (!resp.ok) {
+      throw await resp.json();
+    }
   }
 }

--- a/src/node/NodeHttpClient.ts
+++ b/src/node/NodeHttpClient.ts
@@ -40,6 +40,7 @@ export class NodeHttpClient implements HttpClient {
         ...options?.headers,
         'Content-Type': 'application/json',
       },
+      signal: options?.signal,
     }, (resp) => {
       resp.on('error', reject);
 

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -69,8 +69,15 @@ describe('ShlinkApiClient', () => {
 
       expect(jsonRequest).toHaveBeenCalledWith(
         expect.stringContaining(`/short-urls${expectedQuery}`),
-        expect.anything(),
+        expect.objectContaining({ signal: undefined }),
       );
+    });
+
+    it('passes signal to HTTP client', async () => {
+      const { signal } = new AbortController();
+      await apiClient.listShortUrls({}, signal);
+
+      expect(jsonRequest).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal }));
     });
   });
 

--- a/test/node/NodeHttpClient.test.ts
+++ b/test/node/NodeHttpClient.test.ts
@@ -77,7 +77,7 @@ describe('NodeHttpClient', () => {
     });
 
     it.each([
-      ['http://example.com', (agent: any) => expect(agent).not.toBeDefined()],
+      ['http://example.com', (agent: any) => expect(agent).toBeUndefined()],
       ['https://example.com', (agent: any) => expect(agent).toBeDefined()],
     ])('sets proper agent based on URL schema', async (url, assertAgent) => {
       const { request, httpClient } = createHttpClient({ invokeEnd: true });
@@ -85,6 +85,16 @@ describe('NodeHttpClient', () => {
       await httpClient.emptyRequest(url);
 
       assertAgent(request.mock.lastCall?.[1].agent);
+      expect(request.mock.lastCall?.[1].signal).toBeUndefined();
+    });
+
+    it('propagates signal to HTTP request if provided', async () => {
+      const { httpClient, request } = createHttpClient({ invokeEnd: true });
+      const { signal } = new AbortController();
+
+      await httpClient.emptyRequest('', { signal });
+
+      expect(request.mock.lastCall?.[1].signal).toEqual(signal);
     });
   });
 


### PR DESCRIPTION
Closes #8 

Add an optional last `AbortSignal` parameter to all `ShlinkApiClient` methods, and propagate it to the HTTP Clients, so that it is possible to abort a request.