### PR TITLE
Drop support for Shlink older than 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#229](https://github.com/shlinkio/shlink-js-sdk/issues/229) Drop support for Shlink older than 3.5.0.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [1.4.0] - 2025-01-26
 ### Added
 * [#8](https://github.com/shlinkio/shlink-js-sdk/issues/8) Allow an `AbortSignal` to be provided as the last optional argument to all public `ShlinkApiClient` methods.

--- a/src/api-contract/errors.ts
+++ b/src/api-contract/errors.ts
@@ -1,5 +1,6 @@
 /**
  * Possible error types returned by Shlink's API
+ * @todo convert in a regular frozen object
  */
 export enum ErrorType {
   INVALID_ARGUMENT = 'https://shlink.io/api/error/invalid-data',

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -93,8 +93,7 @@ export type ShlinkHealth = {
 export type ShlinkTagsStats = {
   tag: string;
   shortUrlsCount: number;
-  /** Optional only before Shlink 3.5.0 */
-  visitsSummary?: ShlinkVisitsSummary;
+  visitsSummary: ShlinkVisitsSummary;
 
   /** @deprecated Not returned by Shlink 4.0.0. Use `visitsSummary.total` instead */
   visitsCount?: number;
@@ -169,10 +168,8 @@ export type ShlinkDeleteVisitsResult = {
 };
 
 export type ShlinkVisitsOverview = {
-  /** Optional only before Shlink 3.5.0 */
-  nonOrphanVisits?: ShlinkVisitsSummary;
-  /** Optional only before Shlink 3.5.0 */
-  orphanVisits?: ShlinkVisitsSummary;
+  nonOrphanVisits: ShlinkVisitsSummary;
+  orphanVisits: ShlinkVisitsSummary;
 
   /** @deprecated Use `nonOrphanVisits.total` instead */
   visitsCount?: number;

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -45,13 +45,13 @@ export type ServerInfo = {
 };
 
 export class ShlinkApiClient implements BaseShlinkApiClient {
-  private apiVersion: ApiVersion;
+  #apiVersion: ApiVersion;
 
   public constructor(
     private readonly httpClient: HttpClient,
     private readonly serverInfo: ServerInfo,
   ) {
-    this.apiVersion = 3;
+    this.#apiVersion = 3;
   }
 
   // Short URLs
@@ -68,7 +68,6 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   public async createShortUrl(options: ShlinkCreateShortUrlData, signal?: AbortSignal): Promise<ShlinkShortUrl> {
     const body = Object.entries(options).reduce<any>((obj, [key, value]) => {
       if (value) {
-
         obj[key] = value;
       }
       return obj;
@@ -243,7 +242,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     const stringifiedQuery = !normalizedQuery ? '' : `?${normalizedQuery}`;
     const baseUrl = domain ? replaceAuthorityFromUri(this.serverInfo.baseUrl, domain) : this.serverInfo.baseUrl;
 
-    return [`${buildShlinkBaseUrl(baseUrl, this.apiVersion)}${url}${stringifiedQuery}`, {
+    return [`${buildShlinkBaseUrl(baseUrl, this.#apiVersion)}${url}${stringifiedQuery}`, {
       method,
       body: body && JSON.stringify(body),
       headers: { 'X-Api-Key': this.serverInfo.apiKey },


### PR DESCRIPTION
Closes #229 

Adjust type definitions so that they match what's true for Shlink >=3.5.0