### PR TITLE
Wrap shortCode and domain together in ShortUrlIdentifier object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
-* [#229](https://github.com/shlinkio/shlink-js-sdk/issues/229) Drop support for Shlink older than 3.5.0.
+* *Nothing*
 
 ### Changed
-* *Nothing*
+* [#228](https://github.com/shlinkio/shlink-js-sdk/issues/228) When any method of the `ShlinkApiClient` can receive both a `shortCode` and a `domain`, they are now together in a new `ShortUrlIdentifier` object.
 
 ### Deprecated
 * *Nothing*
 
 ### Removed
-* *Nothing*
+* [#229](https://github.com/shlinkio/shlink-js-sdk/issues/229) Drop support for Shlink older than 3.5.0.
 
 ### Fixed
 * *Nothing*

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -9,17 +9,22 @@ import type {
   ShlinkMercureInfo,
   ShlinkOrphanVisitsParams,
   ShlinkRedirectRulesList,
+  ShlinkRenaming,
   ShlinkSetRedirectRulesData,
   ShlinkShortUrl,
+  ShlinkShortUrlIdentifier,
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
-  ShlinkShortUrlVisitsParams,
   ShlinkTagsList,
   ShlinkTagsStatsList,
   ShlinkVisitsList,
   ShlinkVisitsOverview,
   ShlinkVisitsParams,
 } from './types';
+
+// type Abortable = {
+//   signal?: AbortSignal;
+// };
 
 export type ShlinkApiClient = {
   // Short URLs
@@ -28,13 +33,12 @@ export type ShlinkApiClient = {
 
   createShortUrl(options: ShlinkCreateShortUrlData, signal?: AbortSignal): Promise<ShlinkShortUrl>;
 
-  getShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<ShlinkShortUrl>;
+  getShortUrl(shortUrlId: ShlinkShortUrlIdentifier, signal?: AbortSignal): Promise<ShlinkShortUrl>;
 
-  deleteShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<void>;
+  deleteShortUrl(shortUrlId: ShlinkShortUrlIdentifier, signal?: AbortSignal): Promise<void>;
 
   updateShortUrl(
-    shortCode: string,
-    domain: string | null | undefined,
+    shortUrlId: ShlinkShortUrlIdentifier,
     data: ShlinkEditShortUrlData,
     signal?: AbortSignal,
   ): Promise<ShlinkShortUrl>;
@@ -42,14 +46,12 @@ export type ShlinkApiClient = {
   // Short URL redirect rules
 
   getShortUrlRedirectRules(
-    shortCode: string,
-    domain?: string | null,
+    shortUrlId: ShlinkShortUrlIdentifier,
     signal?: AbortSignal,
   ): Promise<ShlinkRedirectRulesList>;
 
   setShortUrlRedirectRules(
-    shortCode: string,
-    domain: string | null | undefined,
+    shortUrlId: ShlinkShortUrlIdentifier,
     data: ShlinkSetRedirectRulesData,
     signal?: AbortSignal,
   ): Promise<ShlinkRedirectRulesList>;
@@ -59,8 +61,8 @@ export type ShlinkApiClient = {
   getVisitsOverview(signal?: AbortSignal): Promise<ShlinkVisitsOverview>;
 
   getShortUrlVisits(
-    shortCode: string,
-    params?: ShlinkShortUrlVisitsParams,
+    shortUrlId: ShlinkShortUrlIdentifier,
+    params?: ShlinkVisitsParams,
     signal?: AbortSignal,
   ): Promise<ShlinkVisitsList>;
 
@@ -73,8 +75,7 @@ export type ShlinkApiClient = {
   getNonOrphanVisits(params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
 
   deleteShortUrlVisits(
-    shortCode: string,
-    domain?: string | null,
+    shortUrlId: ShlinkShortUrlIdentifier,
     signal?: AbortSignal,
   ): Promise<ShlinkDeleteVisitsResult>;
 
@@ -88,7 +89,7 @@ export type ShlinkApiClient = {
 
   deleteTags(tags: string[], signal?: AbortSignal): Promise<{ tags: string[] }>;
 
-  editTag(oldName: string, newName: string, signal?: AbortSignal): Promise<{ oldName: string; newName: string }>;
+  editTag(renaming: ShlinkRenaming, signal?: AbortSignal): Promise<ShlinkRenaming>;
 
   // Domains
 

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -19,8 +19,12 @@ export type ShlinkShortUrlMeta = {
   maxVisits?: number;
 };
 
-export type ShlinkShortUrl = {
+export type ShlinkShortUrlIdentifier = {
   shortCode: string;
+  domain?: string | null;
+};
+
+export type ShlinkShortUrl = Required<ShlinkShortUrlIdentifier> & {
   shortUrl: string;
   longUrl: string;
   dateCreated: string;
@@ -28,7 +32,6 @@ export type ShlinkShortUrl = {
   visitsSummary?: ShlinkVisitsSummary;
   meta: Required<Nullable<ShlinkShortUrlMeta>>;
   tags: string[];
-  domain: string | null;
   title?: string | null;
   crawlable?: boolean;
   forwardQuery?: boolean;
@@ -185,10 +188,6 @@ export type ShlinkVisitsParams = {
   excludeBots?: boolean;
 };
 
-export type ShlinkShortUrlVisitsParams = ShlinkVisitsParams & {
-  domain?: string | null;
-};
-
 export type ShlinkOrphanVisitsParams = ShlinkVisitsParams & {
   /** Ignored by Shlink older than v4.0.0 */
   type?: ShlinkOrphanVisitType;
@@ -264,4 +263,9 @@ export type ShlinkRedirectRulesList = {
 
 export type ShlinkSetRedirectRulesData = {
   redirectRules: ShlinkRedirectRuleData[];
+};
+
+export type ShlinkRenaming = {
+  oldName: string;
+  newName: string;
 };

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -10,11 +10,12 @@ import type {
   ShlinkMercureInfo,
   ShlinkOrphanVisitsParams,
   ShlinkRedirectRulesList,
+  ShlinkRenaming,
   ShlinkSetRedirectRulesData,
   ShlinkShortUrl,
+  ShlinkShortUrlIdentifier,
   ShlinkShortUrlsList,
   ShlinkShortUrlsListParams,
-  ShlinkShortUrlVisitsParams,
   ShlinkTagsList,
   ShlinkTagsStatsList,
   ShlinkVisitsList,
@@ -75,17 +76,19 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     return this.performRequest<ShlinkShortUrl>({ url: '/short-urls', method: 'POST', body, signal });
   }
 
-  public async getShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<ShlinkShortUrl> {
+  public async getShortUrl(
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
+    signal?: AbortSignal,
+  ): Promise<ShlinkShortUrl> {
     return this.performRequest<ShlinkShortUrl>({ url: `/short-urls/${shortCode}`, query: { domain }, signal });
   }
 
-  public async deleteShortUrl(shortCode: string, domain?: string | null, signal?: AbortSignal): Promise<void> {
+  public async deleteShortUrl({ shortCode, domain }: ShlinkShortUrlIdentifier, signal?: AbortSignal): Promise<void> {
     return this.performEmptyRequest({ url: `/short-urls/${shortCode}`, method: 'DELETE', query: { domain }, signal });
   }
 
   public async updateShortUrl(
-    shortCode: string,
-    domain: string | null | undefined,
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
     data: ShlinkEditShortUrlData,
     signal?: AbortSignal,
   ): Promise<ShlinkShortUrl> {
@@ -97,8 +100,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   // Short URL redirect rules
 
   public async getShortUrlRedirectRules(
-    shortCode: string,
-    domain?: string | null,
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
     signal?: AbortSignal,
   ): Promise<ShlinkRedirectRulesList> {
     return this.performRequest<ShlinkRedirectRulesList>(
@@ -107,8 +109,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   }
 
   public async setShortUrlRedirectRules(
-    shortCode: string,
-    domain: string | null | undefined,
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
     data: ShlinkSetRedirectRulesData,
     signal?: AbortSignal,
   ): Promise<ShlinkRedirectRulesList> {
@@ -126,11 +127,11 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   }
 
   public async getShortUrlVisits(
-    shortCode: string,
-    params?: ShlinkShortUrlVisitsParams,
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
+    params?: ShlinkVisitsParams,
     signal?: AbortSignal,
   ): Promise<ShlinkVisitsList> {
-    return this.performVisitsRequest({ url: `/short-urls/${shortCode}/visits`, query: params, signal });
+    return this.performVisitsRequest({ url: `/short-urls/${shortCode}/visits`, query: { ...params, domain }, signal });
   }
 
   public async getTagVisits(tag: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
@@ -158,8 +159,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   }
 
   public async deleteShortUrlVisits(
-    shortCode: string,
-    domain?: string | null,
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
     signal?: AbortSignal,
   ): Promise<ShlinkDeleteVisitsResult> {
     const query = domain ? { domain } : undefined;
@@ -186,11 +186,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     return this.performEmptyRequest({ url: '/tags', method: 'DELETE', query: { tags }, signal }).then(() => ({ tags }));
   }
 
-  public async editTag(
-    oldName: string,
-    newName: string,
-    signal?: AbortSignal,
-  ): Promise<{ oldName: string; newName: string }> {
+  public async editTag({ oldName, newName }: ShlinkRenaming, signal?: AbortSignal): Promise<ShlinkRenaming> {
     return this.performEmptyRequest({ url: '/tags', method: 'PUT', body: { oldName, newName }, signal })
       .then(() => ({ oldName, newName }));
   }

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -113,7 +113,7 @@ describe('ShlinkApiClient', () => {
         },
       });
 
-      const actualVisits = await apiClient.getShortUrlVisits('abc123', {});
+      const actualVisits = await apiClient.getShortUrlVisits({ shortCode: 'abc123' });
 
       expect({ data: expectedVisits }).toEqual(actualVisits);
       expect(jsonRequest).toHaveBeenCalledWith(
@@ -132,7 +132,7 @@ describe('ShlinkApiClient', () => {
       const response = { deletedVisits: 10 };
       jsonRequest.mockResolvedValue(response);
 
-      const actualVisits = await apiClient.deleteShortUrlVisits('abc123', domain);
+      const actualVisits = await apiClient.deleteShortUrlVisits({ shortCode: 'abc123', domain });
 
       expect(actualVisits).toEqual(response);
       expect(jsonRequest).toHaveBeenCalledWith(
@@ -185,7 +185,7 @@ describe('ShlinkApiClient', () => {
       jsonRequest.mockResolvedValue(expectedShortUrl);
       const expectedQuery = domain ? `?domain=${domain}` : '';
 
-      const result = await apiClient.getShortUrl(shortCode, domain);
+      const result = await apiClient.getShortUrl({ shortCode, domain });
 
       expect(expectedShortUrl).toEqual(result);
       expect(jsonRequest).toHaveBeenCalledWith(
@@ -205,7 +205,7 @@ describe('ShlinkApiClient', () => {
       jsonRequest.mockResolvedValue(expectedResp);
       const expectedQuery = domain ? `?domain=${domain}` : '';
 
-      const result = await apiClient.updateShortUrl(shortCode, domain, meta);
+      const result = await apiClient.updateShortUrl({ shortCode, domain }, meta);
 
       expect(expectedResp).toEqual(result);
       expect(jsonRequest).toHaveBeenCalledWith(
@@ -273,7 +273,7 @@ describe('ShlinkApiClient', () => {
       const oldName = 'foo';
       const newName = 'bar';
 
-      await apiClient.editTag(oldName, newName);
+      await apiClient.editTag({ oldName, newName });
 
       expect(emptyRequest).toHaveBeenCalledWith(expect.stringContaining('/tags'), expect.objectContaining({
         method: 'PUT',
@@ -286,7 +286,7 @@ describe('ShlinkApiClient', () => {
     it.each(shortCodesWithDomainCombinations)('properly deletes provided short URL', async (shortCode, domain) => {
       const expectedQuery = domain ? `?domain=${domain}` : '';
 
-      await apiClient.deleteShortUrl(shortCode, domain);
+      await apiClient.deleteShortUrl({ shortCode, domain });
 
       expect(emptyRequest).toHaveBeenCalledWith(
         expect.stringContaining(`/short-urls/${shortCode}${expectedQuery}`),
@@ -421,7 +421,7 @@ describe('ShlinkApiClient', () => {
       };
       jsonRequest.mockResolvedValue(resp);
 
-      const result = await apiClient.getShortUrlRedirectRules('foo', domain);
+      const result = await apiClient.getShortUrlRedirectRules({ shortCode: 'foo', domain });
 
       expect(jsonRequest).toHaveBeenCalledWith(
         expect.stringContaining(`/short-urls/foo/redirect-rules${expectedQuery}`),
@@ -446,7 +446,7 @@ describe('ShlinkApiClient', () => {
       };
       jsonRequest.mockResolvedValue(resp);
 
-      const result = await apiClient.setShortUrlRedirectRules('foo', domain, data);
+      const result = await apiClient.setShortUrlRedirectRules({ shortCode: 'foo', domain }, data);
 
       expect(jsonRequest).toHaveBeenCalledWith(
         expect.stringContaining(`/short-urls/foo/redirect-rules${expectedQuery}`),


### PR DESCRIPTION
Closes #228 

Replace all definitions of individual `shortCode: string, domain?: string | null` parameters in `ShlinkApiClient` methods, with a new `ShortUrlIdentifier` object which has both properties.