### PR TITLE
Make abort signal part of the last optional param in ShlinkApiClient methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 * [#228](https://github.com/shlinkio/shlink-js-sdk/issues/228) When any method of the `ShlinkApiClient` can receive both a `shortCode` and a `domain`, they are now together in a new `ShortUrlIdentifier` object.
+* [#227](https://github.com/shlinkio/shlink-js-sdk/issues/227) Update all `ShlinkApiClient` methods so that the abort signal is part of the last optional object param of every public method.
 
 ### Deprecated
 * *Nothing*

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -1,4 +1,5 @@
 import type {
+  Abortable,
   ShlinkCreateShortUrlData,
   ShlinkDeleteVisitsResult,
   ShlinkDomainRedirects,
@@ -22,84 +23,77 @@ import type {
   ShlinkVisitsParams,
 } from './types';
 
-// type Abortable = {
-//   signal?: AbortSignal;
-// };
-
 export type ShlinkApiClient = {
   // Short URLs
 
-  listShortUrls(params?: ShlinkShortUrlsListParams, signal?: AbortSignal): Promise<ShlinkShortUrlsList>;
+  listShortUrls(params?: ShlinkShortUrlsListParams & Abortable): Promise<ShlinkShortUrlsList>;
 
-  createShortUrl(options: ShlinkCreateShortUrlData, signal?: AbortSignal): Promise<ShlinkShortUrl>;
+  createShortUrl(data: ShlinkCreateShortUrlData, options?: Abortable): Promise<ShlinkShortUrl>;
 
-  getShortUrl(shortUrlId: ShlinkShortUrlIdentifier, signal?: AbortSignal): Promise<ShlinkShortUrl>;
+  getShortUrl(shortUrlId: ShlinkShortUrlIdentifier, options?: Abortable): Promise<ShlinkShortUrl>;
 
-  deleteShortUrl(shortUrlId: ShlinkShortUrlIdentifier, signal?: AbortSignal): Promise<void>;
+  deleteShortUrl(shortUrlId: ShlinkShortUrlIdentifier, options?: Abortable): Promise<void>;
 
   updateShortUrl(
     shortUrlId: ShlinkShortUrlIdentifier,
-    data: ShlinkEditShortUrlData,
-    signal?: AbortSignal,
+    data: ShlinkEditShortUrlData & Abortable,
   ): Promise<ShlinkShortUrl>;
 
   // Short URL redirect rules
 
   getShortUrlRedirectRules(
     shortUrlId: ShlinkShortUrlIdentifier,
-    signal?: AbortSignal,
+    options?: Abortable,
   ): Promise<ShlinkRedirectRulesList>;
 
   setShortUrlRedirectRules(
     shortUrlId: ShlinkShortUrlIdentifier,
-    data: ShlinkSetRedirectRulesData,
-    signal?: AbortSignal,
+    data: ShlinkSetRedirectRulesData & Abortable,
   ): Promise<ShlinkRedirectRulesList>;
 
   // Visits
 
-  getVisitsOverview(signal?: AbortSignal): Promise<ShlinkVisitsOverview>;
+  getVisitsOverview(options?: Abortable): Promise<ShlinkVisitsOverview>;
 
   getShortUrlVisits(
     shortUrlId: ShlinkShortUrlIdentifier,
-    params?: ShlinkVisitsParams,
-    signal?: AbortSignal,
+    params?: ShlinkVisitsParams & Abortable,
   ): Promise<ShlinkVisitsList>;
 
-  getTagVisits(tag: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
+  getTagVisits(tag: string, params?: ShlinkVisitsParams & Abortable): Promise<ShlinkVisitsList>;
 
-  getDomainVisits(domain: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
+  getDomainVisits(domain: string, params?: ShlinkVisitsParams & Abortable): Promise<ShlinkVisitsList>;
 
-  getOrphanVisits(params?: ShlinkOrphanVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
+  getOrphanVisits(params?: ShlinkOrphanVisitsParams & Abortable): Promise<ShlinkVisitsList>;
 
-  getNonOrphanVisits(params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList>;
+  getNonOrphanVisits(params?: ShlinkVisitsParams & Abortable): Promise<ShlinkVisitsList>;
 
   deleteShortUrlVisits(
     shortUrlId: ShlinkShortUrlIdentifier,
-    signal?: AbortSignal,
+    options?: Abortable,
   ): Promise<ShlinkDeleteVisitsResult>;
 
-  deleteOrphanVisits(signal?: AbortSignal): Promise<ShlinkDeleteVisitsResult>;
+  deleteOrphanVisits(options?: Abortable): Promise<ShlinkDeleteVisitsResult>;
 
   // Tags
 
-  listTags(signal?: AbortSignal): Promise<ShlinkTagsList>;
+  listTags(options?: Abortable): Promise<ShlinkTagsList>;
 
-  tagsStats(signal?: AbortSignal): Promise<ShlinkTagsStatsList>;
+  tagsStats(options?: Abortable): Promise<ShlinkTagsStatsList>;
 
-  deleteTags(tags: string[], signal?: AbortSignal): Promise<{ tags: string[] }>;
+  deleteTags(tags: string[], options?: Abortable): Promise<{ tags: string[] }>;
 
-  editTag(renaming: ShlinkRenaming, signal?: AbortSignal): Promise<ShlinkRenaming>;
+  editTag(renaming: ShlinkRenaming, options?: Abortable): Promise<ShlinkRenaming>;
 
   // Domains
 
-  listDomains(signal?: AbortSignal): Promise<ShlinkDomainsList>;
+  listDomains(options?: Abortable): Promise<ShlinkDomainsList>;
 
-  editDomainRedirects(domainRedirects: ShlinkEditDomainRedirects, signal?: AbortSignal): Promise<ShlinkDomainRedirects>;
+  editDomainRedirects(domainRedirects: ShlinkEditDomainRedirects, options?: Abortable): Promise<ShlinkDomainRedirects>;
 
   // Misc
 
-  health(authority?: string, signal?: AbortSignal): Promise<ShlinkHealth>;
+  health(options?: { domain?: string } & Abortable): Promise<ShlinkHealth>;
 
-  mercureInfo(signal?: AbortSignal): Promise<ShlinkMercureInfo>;
+  mercureInfo(options?: Abortable): Promise<ShlinkMercureInfo>;
 };

--- a/src/api-contract/ShlinkApiClient.ts
+++ b/src/api-contract/ShlinkApiClient.ts
@@ -28,7 +28,7 @@ export type ShlinkApiClient = {
 
   listShortUrls(params?: ShlinkShortUrlsListParams & Abortable): Promise<ShlinkShortUrlsList>;
 
-  createShortUrl(data: ShlinkCreateShortUrlData, options?: Abortable): Promise<ShlinkShortUrl>;
+  createShortUrl(data: ShlinkCreateShortUrlData & Abortable): Promise<ShlinkShortUrl>;
 
   getShortUrl(shortUrlId: ShlinkShortUrlIdentifier, options?: Abortable): Promise<ShlinkShortUrl>;
 

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -1,16 +1,18 @@
-type OptionalString = string | null | undefined;
-
-type Nullable<T> = {
+export type Nullable<T> = {
   [P in keyof T]: T[P] | null
+};
+
+export type Abortable = {
+  signal?: AbortSignal;
 };
 
 /**
  * @deprecated Shlink 4.0.0 no longer uses this.
  */
 export type ShlinkDeviceLongUrls = {
-  android?: OptionalString;
-  ios?: OptionalString;
-  desktop?: OptionalString;
+  android?: string | null;
+  ios?: string | null;
+  desktop?: string | null;
 };
 
 export type ShlinkShortUrlMeta = {

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -1,4 +1,5 @@
 import type {
+  Abortable,
   ShlinkApiClient as BaseShlinkApiClient,
   ShlinkCreateShortUrlData,
   ShlinkDeleteVisitsResult,
@@ -66,7 +67,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     ).then(({ shortUrls }) => shortUrls);
   }
 
-  public async createShortUrl(options: ShlinkCreateShortUrlData, signal?: AbortSignal): Promise<ShlinkShortUrl> {
+  public async createShortUrl({ signal, ...options }: ShlinkCreateShortUrlData & Abortable): Promise<ShlinkShortUrl> {
     const body = Object.entries(options).reduce<any>((obj, [key, value]) => {
       if (value) {
         obj[key] = value;
@@ -78,19 +79,21 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   public async getShortUrl(
     { shortCode, domain }: ShlinkShortUrlIdentifier,
-    signal?: AbortSignal,
+    { signal }: Abortable = {},
   ): Promise<ShlinkShortUrl> {
     return this.performRequest<ShlinkShortUrl>({ url: `/short-urls/${shortCode}`, query: { domain }, signal });
   }
 
-  public async deleteShortUrl({ shortCode, domain }: ShlinkShortUrlIdentifier, signal?: AbortSignal): Promise<void> {
+  public async deleteShortUrl(
+    { shortCode, domain }: ShlinkShortUrlIdentifier,
+    { signal }: Abortable = {},
+  ): Promise<void> {
     return this.performEmptyRequest({ url: `/short-urls/${shortCode}`, method: 'DELETE', query: { domain }, signal });
   }
 
   public async updateShortUrl(
     { shortCode, domain }: ShlinkShortUrlIdentifier,
-    data: ShlinkEditShortUrlData,
-    signal?: AbortSignal,
+    { signal, ...data }: ShlinkEditShortUrlData & Abortable,
   ): Promise<ShlinkShortUrl> {
     return this.performRequest<ShlinkShortUrl>(
       { url: `/short-urls/${shortCode}`, method: 'PATCH', query: { domain }, body: data, signal },
@@ -101,7 +104,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   public async getShortUrlRedirectRules(
     { shortCode, domain }: ShlinkShortUrlIdentifier,
-    signal?: AbortSignal,
+    { signal }: Abortable = {},
   ): Promise<ShlinkRedirectRulesList> {
     return this.performRequest<ShlinkRedirectRulesList>(
       { url: `/short-urls/${shortCode}/redirect-rules`, method: 'GET', query: { domain }, signal },
@@ -110,8 +113,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   public async setShortUrlRedirectRules(
     { shortCode, domain }: ShlinkShortUrlIdentifier,
-    data: ShlinkSetRedirectRulesData,
-    signal?: AbortSignal,
+    { signal, ...data }: ShlinkSetRedirectRulesData & Abortable,
   ): Promise<ShlinkRedirectRulesList> {
     return this.performRequest<ShlinkRedirectRulesList>(
       { url: `/short-urls/${shortCode}/redirect-rules`, method: 'POST', query: { domain }, body: data, signal },
@@ -120,7 +122,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   // Visits
 
-  public async getVisitsOverview(signal?: AbortSignal): Promise<ShlinkVisitsOverview> {
+  public async getVisitsOverview({ signal }: Abortable = {}): Promise<ShlinkVisitsOverview> {
     return this.performRequest<{ visits: ShlinkVisitsOverview }>({ url: '/visits', signal }).then(
       ({ visits }) => visits,
     );
@@ -128,29 +130,34 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   public async getShortUrlVisits(
     { shortCode, domain }: ShlinkShortUrlIdentifier,
-    params?: ShlinkVisitsParams,
-    signal?: AbortSignal,
+    { signal, ...params }: ShlinkVisitsParams & Abortable = {},
   ): Promise<ShlinkVisitsList> {
     return this.performVisitsRequest({ url: `/short-urls/${shortCode}/visits`, query: { ...params, domain }, signal });
   }
 
-  public async getTagVisits(tag: string, params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
+  public async getTagVisits(
+    tag: string,
+    { signal, ...params }: ShlinkVisitsParams & Abortable = {},
+  ): Promise<ShlinkVisitsList> {
     return this.performVisitsRequest({ url: `/tags/${tag}/visits`, query: params, signal });
   }
 
   public async getDomainVisits(
     domain: string,
-    params?: ShlinkVisitsParams,
-    signal?: AbortSignal,
+    { signal, ...params }: ShlinkVisitsParams & Abortable = {},
   ): Promise<ShlinkVisitsList> {
     return this.performVisitsRequest({ url: `/domains/${domain}/visits`, query: params, signal });
   }
 
-  public async getOrphanVisits(params?: ShlinkOrphanVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
+  public async getOrphanVisits(
+    { signal, ...params }: ShlinkOrphanVisitsParams & Abortable = {},
+  ): Promise<ShlinkVisitsList> {
     return this.performVisitsRequest({ url: '/visits/orphan', query: params, signal });
   }
 
-  public async getNonOrphanVisits(params?: ShlinkVisitsParams, signal?: AbortSignal): Promise<ShlinkVisitsList> {
+  public async getNonOrphanVisits(
+    { signal, ...params }: ShlinkVisitsParams & Abortable = {},
+  ): Promise<ShlinkVisitsList> {
     return this.performVisitsRequest({ url: '/visits/non-orphan', query: params, signal });
   }
 
@@ -160,7 +167,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   public async deleteShortUrlVisits(
     { shortCode, domain }: ShlinkShortUrlIdentifier,
-    signal?: AbortSignal,
+    { signal }: Abortable = {},
   ): Promise<ShlinkDeleteVisitsResult> {
     const query = domain ? { domain } : undefined;
     return this.performRequest<ShlinkDeleteVisitsResult>(
@@ -168,32 +175,32 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     );
   }
 
-  public async deleteOrphanVisits(signal?: AbortSignal): Promise<ShlinkDeleteVisitsResult> {
+  public async deleteOrphanVisits({ signal }: Abortable = {}): Promise<ShlinkDeleteVisitsResult> {
     return this.performRequest<ShlinkDeleteVisitsResult>({ method: 'DELETE', url: '/visits/orphan', signal });
   }
 
   // Tags
 
-  public async listTags(signal?: AbortSignal): Promise<ShlinkTagsList> {
+  public async listTags({ signal }: Abortable = {}): Promise<ShlinkTagsList> {
     return this.performRequest<{ tags: ShlinkTagsList }>({ url: '/tags', signal }).then(({ tags }) => tags);
   }
 
-  public async tagsStats(signal?: AbortSignal): Promise<ShlinkTagsStatsList> {
+  public async tagsStats({ signal }: Abortable = {}): Promise<ShlinkTagsStatsList> {
     return this.performRequest<{ tags: ShlinkTagsStatsList }>({ url: '/tags/stats', signal }).then(({ tags }) => tags);
   }
 
-  public async deleteTags(tags: string[], signal?: AbortSignal): Promise<{ tags: string[] }> {
+  public async deleteTags(tags: string[], { signal }: Abortable = {}): Promise<{ tags: string[] }> {
     return this.performEmptyRequest({ url: '/tags', method: 'DELETE', query: { tags }, signal }).then(() => ({ tags }));
   }
 
-  public async editTag({ oldName, newName }: ShlinkRenaming, signal?: AbortSignal): Promise<ShlinkRenaming> {
+  public async editTag({ oldName, newName }: ShlinkRenaming, { signal }: Abortable = {}): Promise<ShlinkRenaming> {
     return this.performEmptyRequest({ url: '/tags', method: 'PUT', body: { oldName, newName }, signal })
       .then(() => ({ oldName, newName }));
   }
 
   // Domains
 
-  public async listDomains(signal?: AbortSignal): Promise<ShlinkDomainsList> {
+  public async listDomains({ signal }: Abortable = {}): Promise<ShlinkDomainsList> {
     return this.performRequest<{ domains: ShlinkDomainsList }>({ url: '/domains', signal }).then(
       ({ domains }) => domains,
     );
@@ -201,7 +208,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   public async editDomainRedirects(
     domainRedirects: ShlinkEditDomainRedirects,
-    signal?: AbortSignal,
+    { signal }: Abortable = {},
   ): Promise<ShlinkDomainRedirects> {
     return this.performRequest<ShlinkDomainRedirects>(
       { url: '/domains/redirects', method: 'PATCH', body: domainRedirects, signal },
@@ -210,11 +217,11 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
 
   // Misc
 
-  public async health(domain?: string, signal?: AbortSignal): Promise<ShlinkHealth> {
+  public async health({ domain, signal }: { domain?: string } & Abortable = {}): Promise<ShlinkHealth> {
     return this.performRequest<ShlinkHealth>({ url: '/health', domain, signal });
   }
 
-  public async mercureInfo(signal?: AbortSignal): Promise<ShlinkMercureInfo> {
+  public async mercureInfo({ signal }: Abortable = {}): Promise<ShlinkMercureInfo> {
     return this.performRequest<ShlinkMercureInfo>({ url: '/mercure-info', signal });
   }
 

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -67,8 +67,8 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
     ).then(({ shortUrls }) => shortUrls);
   }
 
-  public async createShortUrl({ signal, ...options }: ShlinkCreateShortUrlData & Abortable): Promise<ShlinkShortUrl> {
-    const body = Object.entries(options).reduce<any>((obj, [key, value]) => {
+  public async createShortUrl({ signal, ...data }: ShlinkCreateShortUrlData & Abortable): Promise<ShlinkShortUrl> {
+    const body = Object.entries(data).reduce<any>((obj, [key, value]) => {
       if (value) {
         obj[key] = value;
       }

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -59,8 +59,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   // Short URLs
 
   public async listShortUrls(
-    params: ShlinkShortUrlsListParams = {},
-    signal?: AbortSignal,
+    { signal, ...params }: ShlinkShortUrlsListParams & Abortable = {},
   ): Promise<ShlinkShortUrlsList> {
     return this.performRequest<{ shortUrls: ShlinkShortUrlsList }>(
       { url: '/short-urls', query: normalizeListParams(params), signal },

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -313,7 +313,7 @@ describe('ShlinkApiClient', () => {
     });
 
     it('allows domain to be overwritten', async () => {
-      await apiClient.health('another-domain.test');
+      await apiClient.health({ domain: 'another-domain.test' });
       expect(jsonRequest).toHaveBeenCalledWith(
         expect.stringMatching(/^https:\/\/another-domain.test/),
         expect.anything(),

--- a/test/api/ShlinkApiClient.test.ts
+++ b/test/api/ShlinkApiClient.test.ts
@@ -75,7 +75,7 @@ describe('ShlinkApiClient', () => {
 
     it('passes signal to HTTP client', async () => {
       const { signal } = new AbortController();
-      await apiClient.listShortUrls({}, signal);
+      await apiClient.listShortUrls({ signal });
 
       expect(jsonRequest).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal }));
     });


### PR DESCRIPTION
Closes #227 

Update all `ShlinkApiClient` methods so that the abort signal is part of the last optional object param of every public method.