### PR TITLE
Pass HTTP credentials through to the API server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
-* *Nothing*
+* [#273](https://github.com/shlinkio/shlink-js-sdk/pull/273) Allow users to provide a `credentials` parameter to the underlying `[Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) made by `ShlinkClient`s.
 
 ### Changed
 * [#238](https://github.com/shlinkio/shlink-js-sdk/issues/238) Enable `erasableSyntaxOnly` when typechecking.

--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -1,7 +1,10 @@
+export type RequestCredentials = 'omit' | 'same-origin' | 'include';
+
 export type RequestOptions = {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: string;
   headers?: Record<string, string>;
+  credentials?: RequestCredentials;
   signal?: AbortSignal;
 };
 

--- a/src/api/ShlinkApiClient.ts
+++ b/src/api/ShlinkApiClient.ts
@@ -23,7 +23,7 @@ import type {
   ShlinkVisitsOverview,
   ShlinkVisitsParams,
 } from '../api-contract';
-import type { HttpClient, RequestOptions } from './HttpClient';
+import type { HttpClient, RequestCredentials, RequestOptions } from './HttpClient';
 import type { ApiVersion } from './utils';
 import {
   buildShlinkBaseUrl,
@@ -31,6 +31,10 @@ import {
   queryParamsToString,
   replaceAuthorityFromUri,
 } from './utils';
+
+export type ShlinkApiClientOptions = {
+  requestCredentials?: RequestCredentials;
+};
 
 type ShlinkRequestOptions = {
   url: string;
@@ -50,11 +54,13 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
   #apiVersion: ApiVersion;
   readonly #httpClient: HttpClient;
   readonly #serverInfo: ServerInfo;
+  readonly #clientOptions: ShlinkApiClientOptions;
 
-  public constructor(httpClient: HttpClient, serverInfo: ServerInfo)
+  public constructor(httpClient: HttpClient, serverInfo: ServerInfo, clientOptions: ShlinkApiClientOptions = {})
   {
     this.#httpClient = httpClient;
     this.#serverInfo = serverInfo;
+    this.#clientOptions = clientOptions;
     this.#apiVersion = 3;
   }
 
@@ -250,6 +256,7 @@ export class ShlinkApiClient implements BaseShlinkApiClient {
       method,
       body: body && JSON.stringify(body),
       headers: { 'X-Api-Key': this.#serverInfo.apiKey },
+      credentials: this.#clientOptions.requestCredentials,
       signal,
     }];
   }

--- a/test/unit/api/ShlinkApiClient.test.ts
+++ b/test/unit/api/ShlinkApiClient.test.ts
@@ -26,6 +26,22 @@ describe('ShlinkApiClient', () => {
     apiClient = new ShlinkApiClient(httpClient, { baseUrl: 'https://s.test', apiKey: '' });
   });
 
+  describe('with custom client options', () => {
+    it('allows passing HTTP credentials along to the API server', async () => {
+      const apiClient = new ShlinkApiClient(httpClient,
+        { baseUrl: 'https://s.test', apiKey: '' },
+        { requestCredentials: 'include' },
+      );
+
+      await apiClient.health();
+
+      expect(jsonRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ credentials: 'include' }),
+      );
+    });
+  });
+
   describe('listShortUrls', () => {
     const expectedList = ['foo', 'bar'];
 


### PR DESCRIPTION
Closes shlinkio/shlink-web-client#1510

Note that this is a no-op without coordination from the backend API server. If the backend doesn't set the appropriate CORS headers (that explicitly includes the `Origin` of the web client), the client *will not* send credentials.