### PR TITLE
Add support for Shlink 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - name: 'bun'
 #            version: '1.x' # Version selectors do not work https://github.com/oven-sh/setup-bun/issues/37
             version: '1.2.2'
-        shlink-version: ['4.6', '4.5', '4.4', '4.3', '4.2', '4.1', '4.0']
+        shlink-version: ['5.0', '4.6', '4.5', '4.4', '4.3', '4.2', '4.1', '4.0']
         shlink-api-version: ['3']
     steps:
       - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.1.0] - 2026-01-11
+### Added
+* Add support for `before-date` and `after-date` redirect conditions, introduced in Shlink 5.0.0
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [3.0.1] - 2025-11-07
 ### Added
 * *Nothing*

--- a/src/api-contract/types.ts
+++ b/src/api-contract/types.ts
@@ -223,7 +223,9 @@ export type ShlinkRedirectConditionType =
   | 'valueless-query-param' // Since Shlink 4.5.0
   | 'ip-address'
   | 'geolocation-country-code' // Since Shlink 4.3.0
-  | 'geolocation-city-name'; // Since Shlink 4.3.0
+  | 'geolocation-city-name' // Since Shlink 4.3.0
+  | 'before-date' // Since Shlink 5.0.0
+  | 'after-date'; // Since Shlink 5.0.0
 
 export type ShlinkDeviceType =
   | 'android'


### PR DESCRIPTION
Add support for `before-date` and `after-date` redirect conditions, introduced in Shlink 5.0.0.

Additionally, include Shlink 5.0 to the integration tests matrix.